### PR TITLE
fixed window reload bug in the placeholder view

### DIFF
--- a/views/placeholder.ejs
+++ b/views/placeholder.ejs
@@ -110,7 +110,7 @@
       fetch('/', {
         method: 'HEAD'
       }).then(res => {
-        if (!res.headers.has('X-Powered-By') || !res.headers.get('X-Powered-By') === 'ContainerNursery') {
+        if (!res.headers.has('X-Powered-By') || res.headers.get('X-Powered-By') !== 'ContainerNursery') {
           window.location.reload(true)
         }
       }).catch(_ => {


### PR DESCRIPTION
I noticed that my express applications would not reload after starting because they used the powered by header to say that they are powered by express. This change to the code fixes that issue. 