### PR TITLE
container health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ build/
 
 # Config file
 config/config.yml
+
+# dev env
+.devcontainer


### PR DESCRIPTION
I was having problems with the proxy if containers got turned off by something other than the proxy timeout. For example, if I manually turned off one of the containers the proxy was trying to control. When doing that the proxy would just say the host is unreachable. I added a health check for each container that the nursery is in charge of. If the health check fails the stop function is called to give the container the correct values for its boolean variables. This fixes the issue allowing the proxy to start the container once again if someone tries to access it after the manual shutdown. 