### PR TITLE
Additional Solution: Configurable Proxy Listening Port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ build/
 
 # Config file
 config/config.yml
+
+# Dev Env
+.devcontainer

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Property | Meaning
 
 ### Example Configuration
 ```yaml
+proxyListeningPort: 80 #the port the proxy will listen on
 proxyHosts:
   - domain: handbrake.yourdomain.io
     containerName: handbrake

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Property | Meaning
 
 ### Example Configuration
 ```yaml
-proxyListeningPort: 80 #the port the proxy will listen on
+proxyListeningPort: 80
 proxyHosts:
   - domain: handbrake.yourdomain.io
     containerName: handbrake

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -4,3 +4,4 @@ proxyHosts:
     proxyHost: localhost
     proxyPort: 5800
     timeoutSeconds: 15
+proxyListeningPort: 80

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -37,8 +37,8 @@ export default class ConfigManager {
   public getProxyListeningPort(): number {
     if (this.proxyListeningPort) return this.proxyListeningPort;
 
-    if (process.env.PORT) {
-      this.proxyListeningPort = ConfigManager.parsePort(process.env.PORT);
+    if (process.env.CN_PORT) {
+      this.proxyListeningPort = ConfigManager.parsePort(process.env.CN_PORT);
       if (this.proxyListeningPort) return this.proxyListeningPort;
     }
 

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -5,6 +5,8 @@ import logger from './Logger';
 import ProxyHost from './ProxyHost';
 import EventEmitter from 'events';
 
+const placeholderServerListeningPort = 8080;
+
 export default class ConfigManager {
   private configFile = 'config/config.yml';
   private proxyHosts: Map<string, ProxyHost>;
@@ -35,11 +37,17 @@ export default class ConfigManager {
   }
 
   public getProxyListeningPort(): number {
-    if (this.proxyListeningPort) return this.proxyListeningPort;
+    if (this.proxyListeningPort
+      && this.proxyListeningPort !== placeholderServerListeningPort) {
+      return this.proxyListeningPort;
+    }
 
     if (process.env.CN_PORT) {
       this.proxyListeningPort = ConfigManager.parsePort(process.env.CN_PORT);
-      if (this.proxyListeningPort) return this.proxyListeningPort;
+      if (this.proxyListeningPort
+        && this.proxyListeningPort !== placeholderServerListeningPort) {
+        return this.proxyListeningPort;
+      }
     }
 
     this.proxyListeningPort = 80;

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -42,7 +42,8 @@ export default class ConfigManager {
       if (this.proxyListeningPort) return this.proxyListeningPort;
     }
 
-    return 80;
+    this.proxyListeningPort = 80;
+    return this.proxyListeningPort;
   }
 
   private createIfNotExist(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const proxy = createProxyServer({
   xfwd: true
 });
 
-const proxyListeningPort = 80;
+const proxyListeningPort = configManager.getProxyListeningPort();
 const placeholderServerListeningPort = 8080;
 const placeholderServerListeningHost = '127.0.0.1';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const proxy = createProxyServer({
   xfwd: true
 });
 
-const proxyListeningPort = configManager.getProxyListeningPort();
+var proxyListeningPort = configManager.getProxyListeningPort();
 const placeholderServerListeningPort = 8080;
 const placeholderServerListeningHost = '127.0.0.1';
 
@@ -79,6 +79,14 @@ proxyServer.on('upgrade', (req, socket, head) => {
 
 proxyServer.listen(proxyListeningPort);
 logger.info({ port: proxyListeningPort }, 'Proxy listening');
+
+configManager.on('port-update', () => {
+  proxyListeningPort = configManager.getProxyListeningPort();
+  proxyServer.close(() => {
+    proxyServer.listen(proxyListeningPort);
+    logger.info({ port: proxyListeningPort }, 'Proxy listening');
+  });
+});
 
 const placeholderServer = express();
 placeholderServer.set('views', 'views');


### PR DESCRIPTION
Here is another way to achieve #1 as an alternative to #13 Here I utilize an event emitter instead of an exported function. 