### PR TITLE
disable loading page feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following top-level properties can be configured:
 Property | Meaning
 ---------|--------|
 `proxyListeningPort` | The port ContainerNursery should listen on for new http connections. Defaults to `80`.
+`disableDefaultLoadingPage` | Boolean for disable the default loading page. By disabling the default loading page the request waits for the container and responds when the container is ready. Defaults to `false`.
 
 The virtual hosts the proxy should handle can be configured by adding an object to the `proxyHosts` key.
 
@@ -68,6 +69,8 @@ The following properties are optional:
 | `proxyUseHttps`                | Boolean indicating if the proxy should use HTTPS to connect to the container. Defaults to `false`. This should only be used if the container only accepts HTTPS requests. It provides no additional security.                                                                                                                                                                                            |
 | `stopOnTimeoutIfCpuUsageBelow` | If set, prevents the container from stopping when reaching the configured timeout if the averaged CPU usage (percentage between 0 and 100*core count) of the **main** container (first in the list of container names) is above this value. This is great for containers that should remain running while their doing intensive work even when nobody is doing any http requests, for example handbrake. |
 | `proxyUseCustomMethod` | Can be set to a HTTP method (`HEAD`,`GET`, ...) which should be used for the ready check. Some services only respond to certain HTTP methods correctly. |
+| `enableDefaultLoadingPage` | Boolean for enable the default loading page when `disableDefaultLoadingPage` is set to `true`. |
+| `customHttpStatusReadyChecking` | Custom Http status number use to check if the container is ready and running. |
 
 ### Example Configuration
 ```yaml

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -7,6 +7,7 @@ proxyHosts:
     proxyPort: 5800
     timeoutSeconds: 15
     stopOnTimeoutIfCpuUsageBelow: 50
+    disableDefaultLoadingPage: false
   - domain:
       - wordpress.yourdomain.io
       - wordpress.otherdomain.io

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -1,4 +1,5 @@
 proxyListeningPort: 80
+disableDefaultLoadingPage: true
 proxyHosts:
   - domain: handbrake.yourdomain.io
     containerName: handbrake
@@ -7,7 +8,7 @@ proxyHosts:
     proxyPort: 5800
     timeoutSeconds: 15
     stopOnTimeoutIfCpuUsageBelow: 50
-    disableDefaultLoadingPage: false
+    enableDefaultLoadingPage: true
   - domain:
       - wordpress.yourdomain.io
       - wordpress.otherdomain.io

--- a/src/ConfigManager.ts
+++ b/src/ConfigManager.ts
@@ -18,6 +18,7 @@ type ProxyHostConfig = {
   proxyUseCustomMethod: string
   timeoutSeconds: number
   stopOnTimeoutIfCpuUsageBelow?: number
+  disableDefaultLoadingPage?:boolean
 }
 type ApplicationConfig = {
   proxyListeningPort: number,
@@ -139,6 +140,10 @@ export default class ConfigManager {
 
         if (proxyHostConfig.stopOnTimeoutIfCpuUsageBelow) {
           proxyHost.stopOnTimeoutIfCpuUsageBelow = proxyHostConfig.stopOnTimeoutIfCpuUsageBelow as number;
+        }
+
+        if (proxyHostConfig.disableDefaultLoadingPage) {
+          proxyHost.disableDefaultLoadingPage = proxyHostConfig.disableDefaultLoadingPage;
         }
 
         if (proxyHostConfig.domain instanceof Array) {

--- a/src/ProxyHost.ts
+++ b/src/ProxyHost.ts
@@ -13,10 +13,12 @@ export default class ProxyHost {
   private proxyHost: string;
   private proxyPort: number;
   public proxyUseHttps = false;
+  public customHttpStatusReadyChecking: number | undefined
   public proxyUseCustomMethod: string | undefined;
   private timeoutSeconds: number;
   public stopOnTimeoutIfCpuUsageBelow = Infinity;
   public disableDefaultLoadingPage = false
+  public enableDefaultLoadingPage = false
 
   private activeSockets: Set<internal.Duplex> = new Set();
   private containerEventEmitter: EventEmitter | null = null;
@@ -168,7 +170,10 @@ export default class ProxyHost {
           headers: res.headers
         }, 'Checked if target is ready');
 
-        if (res.status === 200 || (res.status >= 300 && res.status <= 399)) {
+        if (
+          res.status === 200 || (res.status >= 300 && res.status <= 399)
+          || (this.customHttpStatusReadyChecking && res.status === this.customHttpStatusReadyChecking)
+        ) {
           clearInterval(checkInterval);
           this.containerReadyChecking = false;
           this.containerRunning = true;

--- a/src/ProxyHost.ts
+++ b/src/ProxyHost.ts
@@ -16,6 +16,7 @@ export default class ProxyHost {
   public proxyUseCustomMethod: string | undefined;
   private timeoutSeconds: number;
   public stopOnTimeoutIfCpuUsageBelow = Infinity;
+  public disableDefaultLoadingPage = false
 
   private activeSockets: Set<internal.Duplex> = new Set();
   private containerEventEmitter: EventEmitter | null = null;
@@ -135,6 +136,18 @@ export default class ProxyHost {
 
     this.checkContainerReady();
     this.startingHost = false;
+  }
+
+  public async isContainerRunning():Promise<boolean> {
+    let interval:NodeJS.Timer;
+    return new Promise((resolve) => {
+      interval = setInterval(async () => {
+        if (this.containerRunning) {
+          resolve(true);
+          clearInterval(interval);
+        }
+      }, 250);
+    });
   }
 
   private checkContainerReady() {


### PR DESCRIPTION
This PR adds an option to disable the default loading page. With this option enabled, the request will hang until the container is ready. Then, the response will be the real response of the container, not the loading page.

In my case, I have an API server. When I call the API, the 200 HTTP response used to be the content of the HTML loading page. With this feature, the 200 response will be the actual server response.

added global config `disableDefaultLoadingPage` for disable all loading page
added proxy config `enableDefaultLoadingPage` for enable loading page if the `disableDefaultLoadingPage=true`
added proxy config `customHttpStatusReadyChecking` for have custom http status for ready check of the container

I would like to thank you of this library for their hard work and dedication. This change will be a valuable addition to the library.

Let me know what u think!

Thank you!